### PR TITLE
WebSocket 라이브러리 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,14 +24,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 웹소켓 라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
- 기존 jpa, security 라이브러리는 사용 예정 없으므로 제거
- STOMP의 실시간 통신을 위해 WebSocket 라이브러리 추가