### PR TITLE
fix: CORS 설정 및 브로커 접두사 재작성

### DIFF
--- a/backend/src/main/java/yeet/backend/config/WebConfig.java
+++ b/backend/src/main/java/yeet/backend/config/WebConfig.java
@@ -10,9 +10,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:3001")
+                .allowedOrigins("*")
                 .allowedMethods("*")
-                .allowedHeaders("*")
-                .allowCredentials(true); // 쿠키 허용 여부
+                .allowedHeaders("*");
     }
 }

--- a/backend/src/main/java/yeet/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/yeet/backend/config/WebSocketConfig.java
@@ -14,14 +14,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry){
 
         registry.setApplicationDestinationPrefixes("/app");
-        registry.enableSimpleBroker("/topic", "/queue", "/user");
+        registry.enableSimpleBroker("/topic", "/queue");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry){
 
         registry.addEndpoint("/ws/connect")
-                .setAllowedOrigins("*")
+                .setAllowedOrigins("http://localhost:3000", "http://localhost:3001")
                 .withSockJS();
     }
 }


### PR DESCRIPTION
- withSockJS() 사용으로 인해 Origin에 와일드카드 사용 불가 (= origin 직접 명시)
- "/user" 접두사는 기본적으로 설정되어 있으며, 만약 선언하고 싶다면 setUserDestinationPrefix()에 선언해야 한다.
- SImpleBroker에 "/user" 접두사 제거