### PR TITLE
feat: 초대 코드 입력 기능 구현 (소켓 팀 채널 통신)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,10 +1,10 @@
-import React from "react";
-
+import React, { useEffect } from "react";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
-
+import GamePlay from "./pages/GamePlay";
 import Lobby from "./pages/Lobby";
 
-const Background = styled.div`
+const BackgroundApp = styled.div`
   color: #2b2b2b;
   background-color: #e5e5e5;
   min-height: 100vh;
@@ -15,10 +15,22 @@ const Background = styled.div`
 `;
 
 function App() {
+  // 게임 시작 여부를 Redux 상태에서 확인
+  const gameStarted = useSelector((state) => state.game.gameStarted);
+  const gameState = useSelector((state) => state.game);
+  console.log("gameStarted 상태:", gameStarted);
+  console.log("game 상태:", gameState);
+
+  useEffect(() => {
+    console.log("game 상태 변경 감지:", gameStarted);
+  }, [gameStarted]);
+
   return (
-    <Background>
-      <Lobby />
-    </Background>
+    <BackgroundApp>
+      {/* gameStarted 값에 따라 화면 전환 */}
+      {gameStarted === true ? <GamePlay /> : <Lobby />}
+      {/* <GamePlay /> */}
+    </BackgroundApp>
   );
 }
 

--- a/frontend/src/components/common/Modals/ModalContents/WithFriendsModal.jsx
+++ b/frontend/src/components/common/Modals/ModalContents/WithFriendsModal.jsx
@@ -2,9 +2,10 @@ import React, { useState, useRef } from "react";
 import styled from "styled-components";
 import PrimaryButton from "../../Buttons/PrimaryButton";
 import PrimaryInput from "../../Inputs/PrimaryInput";
-import { createRoom } from "../../../../thunk/roomThunk";
+import { createRoom, joinRoom } from "../../../../thunk/roomThunk";
 import { useDispatch, useSelector } from "react-redux";
 import { setGeneratedRoomCode, setMessage } from "../../../../store/modalSlice";
+import { disconnectStomp } from "../../../../thunk/stompThunk";
 
 const PartContainer = styled.div`
   padding: 1rem;
@@ -28,7 +29,8 @@ const WithFriendsModal = () => {
   const inputRef = useRef(null); // 입력창 참조
 
   const handleCreateRoom = () => {
-    console.log("클릭했슈");
+    console.log("방 만들기 클릭!!");
+
     dispatch(createRoom());
   };
 
@@ -37,9 +39,12 @@ const WithFriendsModal = () => {
       inputRef.current.focus();
       return;
     }
+
+    dispatch(joinRoom(roomCode)); // 방 코드와 닉네임 전달
   };
 
   const handleCancelMatching = () => {
+    dispatch(disconnectStomp()); // STOMP 연결 종료
     dispatch(setGeneratedRoomCode(null));
     dispatch(setMessage("매칭이 취소되었습니다."));
   };

--- a/frontend/src/store/gameSlice.js
+++ b/frontend/src/store/gameSlice.js
@@ -1,0 +1,43 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  currentPlayer: null,
+  rollCount: null,
+  gameStarted: false,
+  GAME_START: {},
+};
+
+const gameSlice = createSlice({
+  name: "game",
+  initialState,
+  reducers: {
+    // currentPlayer 업데이트
+    updateCurrentPlayer(state, action) {
+      state.currentPlayer = action.payload;
+    },
+
+    // rollCount 업데이트
+    updateRollCount(state, action) {
+      state.rollCount = action.payload;
+    },
+
+    // gameStarted 업데이트
+    updateGameStarted(state, action) {
+      state.gameStarted = action.payload;
+    },
+
+    // GAME_START 데이터를 업데이트
+    updateGameStartData(state, action) {
+      state.GAME_START = { ...state.GAME_START, ...action.payload };
+    },
+  },
+});
+
+export const {
+  updateCurrentPlayer,
+  updateRollCount,
+  updateGameStarted,
+  updateGameStartData,
+} = gameSlice.actions;
+
+export default gameSlice.reducer;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,11 +1,13 @@
 import { configureStore } from "@reduxjs/toolkit";
 import modalReducer from "./modalSlice";
 import stompReducer from "./stompSlice";
+import gameReducer from "./gameSlice";
 
 const store = configureStore({
   reducer: {
     modal: modalReducer,
     stomp: stompReducer,
+    game: gameReducer,
   },
 });
 

--- a/frontend/src/thunk/gameThunk.js
+++ b/frontend/src/thunk/gameThunk.js
@@ -1,3 +1,35 @@
+import {
+  updateCurrentPlayer,
+  updateGameStarted,
+  updateRollCount,
+  updateGameStartData,
+} from "../store/gameSlice";
+
+// 타입별 메시지 핸들러
+const handleMessageByType = (data, dispatch) => {
+  // 공통 데이터 업데이트
+  if (data.currentPlayer !== undefined) {
+    dispatch(updateCurrentPlayer(data.currentPlayer));
+  }
+  if (data.rollCount !== undefined) {
+    dispatch(updateRollCount(data.rollCount));
+  }
+  if (data.gameStarted !== undefined) {
+    dispatch(updateGameStarted(data.gameStarted));
+  }
+
+  switch (data.type) {
+    case "GAME_START":
+      console.log("게임 시작 메시지 처리:", data);
+      dispatch(updateGameStartData(data));
+      break;
+
+    default:
+      console.warn("알 수 없는 메시지 타입:", data.type);
+      break;
+  }
+};
+
 // 팀 채널 구독 함수
 export const subscribeToTeamChannel = (client, teamChannelId, dispatch) => {
   console.log(`팀 채널 구독 설정 중: /topic/room/${teamChannelId}`);
@@ -16,6 +48,8 @@ export const subscribeToTeamChannel = (client, teamChannelId, dispatch) => {
           const data = JSON.parse(message.body);
           console.log("팀 채널 메시지 수신:", data);
 
+          // 메시지 타입에 따라 처리
+          handleMessageByType(data, dispatch);
           resolve(subscription); // 구독 객체 반환
         } catch (error) {
           console.error("팀 채널 메시지 처리 중 오류:", error);

--- a/frontend/src/thunk/stompThunk.js
+++ b/frontend/src/thunk/stompThunk.js
@@ -1,6 +1,7 @@
 import stompClientManager from "../utils/stompClient";
 import { connected, disconnected } from "../store/stompSlice";
 import { setGeneratedRoomCode } from "../store/modalSlice";
+import { updateGameStartData } from "../store/gameSlice";
 
 export const connectStomp = () => async (dispatch, getState) => {
   const { connected: isConnected } = getState().stomp;
@@ -26,7 +27,7 @@ export const disconnectStomp = () => async (dispatch) => {
     await stompClientManager.disconnect();
     dispatch(disconnected());
     dispatch(setGeneratedRoomCode(null));
-
+    dispatch(updateGameStartData(null)); // 방 정보 초기화
     console.log("STOMP 연결 해제 성공");
   } catch (error) {
     console.error("STOMP 연결 해제 중 오류:", error);


### PR DESCRIPTION
- 초대 코드를 입력하여 팀 채널로부터 값을 받았다면 사용자가 동시에 게임 페이지로 이동하도록 UI 구현
- 게임이 시작 된 후의 상태 관리를 위한 gameSlice 생성
- 게임 중 로직 관리를 위한 gameThunk에 핸들러 추가
- 초대 코드를 받은 상황에서는 모달의 X 버튼으로 STOMP 연결 해제 기능 추가