### PR TITLE
fix: 점수 선택 동작 수정

### DIFF
--- a/frontend/src/components/GamePaly/DiceKeeper.jsx
+++ b/frontend/src/components/GamePaly/DiceKeeper.jsx
@@ -35,8 +35,10 @@ const DiceWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  cursor: ${(props) => (props.$isDisabled ? "not-allowed" : "pointer")};
-  pointer-events: ${(props) => (props.$isDisabled ? "none" : "auto")};
+  cursor: ${(props) =>
+    props.$isDisabled || props.$rollCountExceeded ? "not-allowed" : "pointer"};
+  pointer-events: ${(props) =>
+    props.$isDisabled || props.$rollCountExceeded ? "none" : "auto"};
   transition: border 0.3s ease;
 
   &:hover {
@@ -56,6 +58,7 @@ const DiceKeeper = ({
   onRoll,
   isDisabled,
   roomCode,
+  rollCount,
 }) => {
   const dispatch = useDispatch();
   const diceIcons = [
@@ -81,6 +84,10 @@ const DiceKeeper = ({
       console.warn("현재 플레이어가 아닙니다!");
       return;
     }
+    if (rollCount >= 3) {
+      console.warn("첫 주사위 돌리기에서는 주사위를 고정할 수 없습니다!");
+      return;
+    }
 
     // 선택 상태 반전
     const updatedSelectedDice = [...selectedDice];
@@ -97,6 +104,7 @@ const DiceKeeper = ({
             key={index}
             $isSelected={selectedDice[index]}
             $isDisabled={isDisabled}
+            $rollCountExceeded={rollCount >= 3} // 기회가 3번이면 호버 비활성화
             onClick={() => handleDiceClick(index)}
           >
             <DiceIcon icon={diceIcons[value - 1]} />

--- a/frontend/src/components/GamePaly/ScoreBoard.jsx
+++ b/frontend/src/components/GamePaly/ScoreBoard.jsx
@@ -18,10 +18,10 @@ const categoryMapping = {
   smallStraight: "Small Straight",
   largeStraight: "Large Straight",
   chance: "Chance",
-  yahtzee: "Yahtzee",
-  sum: "Sum",
-  bonus: "Bonus",
-  total: "Total",
+  yahtzee: "YEET",
+  sum: "SUM",
+  bonus: "BONUS",
+  total: "TOTAL",
 };
 
 const reverseCategoryMapping = Object.fromEntries(
@@ -122,14 +122,14 @@ const ScoreBoard = ({
     { category: "Sixes", Player1: null, Player2: null },
     { category: "Three of a Kind", Player1: null, Player2: null },
     { category: "Four of a Kind", Player1: null, Player2: null },
-    { category: "Sum", Player1: null, Player2: null },
-    { category: "Bonus", Player1: null, Player2: null },
+    { category: "SUM", Player1: null, Player2: null },
+    { category: "BONUS", Player1: null, Player2: null },
     { category: "Full House", Player1: null, Player2: null },
     { category: "Small Straight", Player1: null, Player2: null },
     { category: "Large Straight", Player1: null, Player2: null },
     { category: "Chance", Player1: null, Player2: null },
     { category: "YEET", Player1: null, Player2: null },
-    { category: "Total", Player1: null, Player2: null },
+    { category: "TOTAL", Player1: null, Player2: null },
   ]);
 
   // 점수 선택 핸들러
@@ -149,8 +149,7 @@ const ScoreBoard = ({
     if (choiceScore) {
       setBoardData((prevData) =>
         prevData.map((item) => {
-          const playerKey =
-            enterBoardPlayer === "Player1" ? "Player1" : "Player2";
+          const playerKey = currentPlayer === "Player1" ? "Player1" : "Player2";
           const uiCategory = mapCategoryToUI(choiceScore.category);
           if (item.category === uiCategory) {
             return { ...item, [playerKey]: choiceScore.score };
@@ -159,20 +158,23 @@ const ScoreBoard = ({
         })
       );
     }
-  }, [choiceScore, enterBoardPlayer]);
+  }, [choiceScore, currentPlayer]);
 
   // fixScore 업데이트 처리
   useEffect(() => {
-    if (fixScore) {
+    if (fixScore && enterBoardPlayer) {
       setBoardData((prevData) =>
         prevData.map((item) => {
-          const playerKey =
-            enterBoardPlayer === "Player1" ? "Player1" : "Player2";
-          const uiCategory = mapCategoryToUI(fixScore.category);
-          if (item.category === uiCategory) {
-            return { ...item, [playerKey]: fixScore.score };
+          const serverCategory = mapCategoryToServer(item.category); // 서버 카테고리와 매칭
+
+          // `fixScore`에 해당하는 카테고리가 있다면 업데이트
+          if (fixScore[serverCategory] !== undefined) {
+            return {
+              ...item,
+              [enterBoardPlayer]: fixScore[serverCategory], // KeepScorePlayer 값에 따라 업데이트
+            };
           }
-          return item;
+          return item; // 해당하지 않으면 기존 항목 유지
         })
       );
     }

--- a/frontend/src/pages/GamePlay.jsx
+++ b/frontend/src/pages/GamePlay.jsx
@@ -101,6 +101,7 @@ const GamePlay = () => {
             roomCode={roomCode}
             selectedDice={selectedDice}
             onRoll={handleRollDices}
+            rollCount={rollCount}
             isDisabled={currentPlayer !== player || rollCount === 0}
           />
 


### PR DESCRIPTION
- 주사위가 기회가 3번 이상일 경우 주사위를 한번도 굴리지 않은 것이므로 주사위를 선택하거나 hover할 수 없도록 DiceKeeper 수정
- 점수판에 이전 점수 선택 항목(scoreOptions) 다시 뜨지 않도록 핸들러에서 초기화
- 점수를 선택했다면 상대방의 차례이므로 기회를 3번으로 변경하도록 rollCount 핸들러에서  초기화
- 점수를 선택했다면 상대방의 차례이므로 주사위 고정 상태를 false 값으로 핸들러에서 초기화
- ScoreBoard에서 서버에서 받아온 fixScore값을 해당 플레이어 필드에 업데이트하도록 수정