### PR TITLE
fix: 게임 종료, 다시하기 수정

### DIFF
--- a/frontend/src/store/gameSlice.js
+++ b/frontend/src/store/gameSlice.js
@@ -49,13 +49,34 @@ const gameSlice = createSlice({
 
     // 게임 다시하기 (gameStarted을 제외하고 게임 상태 초기화)
     resetGameStateForRestart(state) {
-      const gameStartedValue = state.gameStarted; // 현재 gameStarted 값 저장
-
-      // initialState를 복사하되 gameStarted만 기존 값 유지
+      // 현재 값들 저장
+      const gameStartedValue = state.gameStarted;
+      const playersValue = state.GAME_START.players;
+      const currentPlayerValue = state.currentPlayer;
+      const rollCountValue = state.rollCount;
+      // initialState를 복사하되 gameStarted, players만 기존 값 유지
+      // currentPlayer와 rollCount는 업데이트
       Object.assign(state, {
         ...initialState,
         gameStarted: gameStartedValue,
+        currentPlayer: currentPlayerValue,
+        rollCount: rollCountValue,
+        GAME_START: {
+          ...state.GAME_START,
+          players: playersValue,
+        },
       });
+
+      // players가 존재하면 scoreBoard 키 업데이트
+      if (playersValue) {
+        state.scoreBoard = state.scoreBoard.map((row) => {
+          return {
+            category: row.category, // category 유지
+            [playersValue[0]]: null, // 첫 번째 플레이어
+            [playersValue[1]]: null, // 두 번째 플레이어
+          };
+        });
+      }
     },
 
     // currentPlayer 업데이트


### PR DESCRIPTION
- 상대방이 게임 종료 시 다시하기 버튼이 비활성화 되지 않는 문제 수정
- 본인이 다시하기를 눌렀다면 서버에 다시 요청하지 않도록 restartRequest로 요청 여부 상태를 관리
- 다시하기에서 데이터 형식에 추가된 내용을 기반으로 다시하기 초기화 상태를 gameSlice 수정 (scoreBoard의 p1, p2값 업데이트 추가)
- 다시하기 버튼 스타일링 추가